### PR TITLE
Get current datetime faster

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -18,7 +18,7 @@ var timeago = function() {
       pl = function(v, n) {
         return (s === undefined) ? n + ' ' + v + (n > 1 ? 's' : '') + ' ago' : n + v.substring(0, 1)
       },
-      ts = new Date().getTime() - new Date(nd).getTime(),
+      ts = Date.now() - new Date(nd).getTime(),
       ii;
     for (var i in o) {
       if (r(ts) < o[i]) return pl(ii || 'm', r(ts / (o[ii] || 1)))


### PR DESCRIPTION
"Date.now()" is faster than "new Date().getTime()" since we don't need to create a new date object.