### PR TITLE
module: export the resulting object and no the function

### DIFF
--- a/timeago.js
+++ b/timeago.js
@@ -48,4 +48,4 @@ var timeago = function() {
 }
 
 if (typeof module !== 'undefined' && module.exports)
-  module.exports = timeago;
+  module.exports = timeago();


### PR DESCRIPTION
As it is right now, to use the module on a node context, this is the process:

```javascript
const ta = require('time-ago')();
```

Or with `import`
```javascript
import ta from 'time-ago';
const time = ta();
```

Both seem unnecessarily cumbersome. This PR addresses that and it would mean that the import or require would not need a subsequent call to the function:

```javascript
const ta = require('time-ago');
```

Or

```javascript
import ta from 'time-ago';
```

I would also suggest that making the function a closure for browser usage is reasonable, to avoid scoping issues.

